### PR TITLE
[#2] Feat: 간단한 monitoring

### DIFF
--- a/src/main/java/com/clover/monitor/domain/monitor/Index.java
+++ b/src/main/java/com/clover/monitor/domain/monitor/Index.java
@@ -1,0 +1,15 @@
+package com.clover.monitor.domain.monitor;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class Index {
+
+	@GetMapping("/")
+	public String index() {
+		return "index";
+	}
+
+
+}

--- a/src/main/java/com/clover/monitor/domain/monitor/api/MonitorController.java
+++ b/src/main/java/com/clover/monitor/domain/monitor/api/MonitorController.java
@@ -1,0 +1,28 @@
+package com.clover.monitor.domain.monitor.api;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.clover.monitor.domain.monitor.service.MonitoringService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/monitor")
+@RequiredArgsConstructor
+public class MonitorController {
+
+	private final MonitoringService monitoringService;
+
+
+	@GetMapping("/start")
+	public void monitoringStart() {
+		monitoringService.startMonitoring();
+	}
+
+	@GetMapping("/stop")
+	public void monitoringStop() {
+		monitoringService.stopMonitoring();
+	}
+}

--- a/src/main/java/com/clover/monitor/domain/monitor/entity/Monitor.java
+++ b/src/main/java/com/clover/monitor/domain/monitor/entity/Monitor.java
@@ -1,0 +1,34 @@
+package com.clover.monitor.domain.monitor.entity;
+
+import com.clover.monitor.global.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Monitor extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	private String name;
+	private String endPoint;
+	private String description;
+	private String method;
+	private String headers;
+	private String params;
+	private String body;
+	@Column(name = "heartbeat")
+	private int interval;
+}

--- a/src/main/java/com/clover/monitor/domain/monitor/service/MonitorServiceImpl.java
+++ b/src/main/java/com/clover/monitor/domain/monitor/service/MonitorServiceImpl.java
@@ -1,0 +1,36 @@
+package com.clover.monitor.domain.monitor.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Timer;
+
+import org.springframework.stereotype.Service;
+
+import com.clover.monitor.domain.monitor.entity.Monitor;
+import com.clover.monitor.global.util.MonitorTask;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MonitorServiceImpl implements MonitoringService {
+	private Timer timer = new Timer();
+
+
+	@Override
+	public void startMonitoring() {
+		List<Monitor> monitorList = new ArrayList<>();
+		monitorList.add(Monitor.builder().endPoint("https://www.naver.com").build());
+		monitorList.add(Monitor.builder().endPoint("https://www.google.com").build());
+		monitorList.add(Monitor.builder().endPoint("https://www.youtube.com").build());
+		for (Monitor monitor : monitorList) {
+			timer.scheduleAtFixedRate(new MonitorTask(monitor),0, 1000);
+		}
+	}
+
+	@Override
+	public void stopMonitoring() {
+		timer.cancel();
+		this.timer = new Timer();
+	}
+}

--- a/src/main/java/com/clover/monitor/domain/monitor/service/MonitoringService.java
+++ b/src/main/java/com/clover/monitor/domain/monitor/service/MonitoringService.java
@@ -1,0 +1,7 @@
+package com.clover.monitor.domain.monitor.service;
+
+public interface MonitoringService {
+	void startMonitoring();
+
+	void stopMonitoring();
+}

--- a/src/main/java/com/clover/monitor/global/config/JpaConfig.java
+++ b/src/main/java/com/clover/monitor/global/config/JpaConfig.java
@@ -1,4 +1,4 @@
-package com.clover.monitor.config;
+package com.clover.monitor.global.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;

--- a/src/main/java/com/clover/monitor/global/entity/BaseEntity.java
+++ b/src/main/java/com/clover/monitor/global/entity/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.clover.monitor.entity;
+package com.clover.monitor.global.entity;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/clover/monitor/global/util/MonitorTask.java
+++ b/src/main/java/com/clover/monitor/global/util/MonitorTask.java
@@ -1,0 +1,34 @@
+package com.clover.monitor.global.util;
+
+import java.util.TimerTask;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import com.clover.monitor.domain.monitor.entity.Monitor;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Component
+public class MonitorTask extends TimerTask {
+
+	private final RestTemplate restTemplate = new RestTemplate();
+
+	private Monitor monitor;
+
+	@Override
+	public void run() {
+		String endPoint = monitor.getEndPoint();
+		long startTime = System.currentTimeMillis();
+		ResponseEntity<String> forEntity = restTemplate.getForEntity(endPoint, String.class);
+		long endTime = System.currentTimeMillis();
+		long duration = endTime - startTime;
+		System.out.println("EndPoint : " + endPoint + " Get Status : " + forEntity.getStatusCode());
+		System.out.println("요청 시간 : " + duration);
+	}
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,4 +11,8 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: none
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+    database-platform: org.hibernate.dialect.H2Dialect

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+    <a href="/monitor/start">모니터링 시작하기</a>
+    <a href="/monitor/stop">모니터링 중지하기</a>
+</body>
+</html>


### PR DESCRIPTION
## 작업 사항
모니터링 시스템을 스프링 스케줄러로 구현 하고자 했으나, 스케줄러는 어플리케이션이 실행됨과 동시에 시간 또는 딜레이를 사용하여 실행됩니다.
원하는 방향은 사용자가 모니터링을 시작과 끝을 직접 컨트롤 해야합니다.
따라서, 자바 타이머를 활용하여 구현해봤습니다.
일단은 임시로 자바 타이머로 구현이 가능할지 판단하기 위한 테스트 구현해보았고, 지속적으로 더 좋은 방안을 찾아볼 계획입니다 ~~😀😀

[config : jpa Database 방언 설정](https://github.com/gombasan/endpoint-watchdog/commit/66c2c86fb7fcb0d155f2d621d1e73388bd6cd89b) 
- h2 Database 방언 설정하였습니다.

[chore(global) : BaseEntity 패키지 변경](https://github.com/gombasan/endpoint-watchdog/commit/ac8e6ca7f48815a0e5249dd4bc1850d6f3e39043) 
- 루트 패키지에서 global 패키지로 이동하였습니다.
 
[docs(html) : index 페이지 추가](https://github.com/gombasan/endpoint-watchdog/commit/5ab60402bde4bf6e00810f0c5077e581d9364bf9) 
- 모니터링 시작과 중지 링크가 있는 index 페이지를 추가하였습니다.
 
[feat(controller) : index Controller 추가](https://github.com/gombasan/endpoint-watchdog/commit/dd03225823cf6168e8f50f2d9a773e957fce65f9) 
- 모니터링 시작과 중지 링크가 있는 index 페이지를 반환합니다.
 
[chore(global) : JpaConfig 패키지 변경](https://github.com/gombasan/endpoint-watchdog/commit/f3dbf03001e2ab93ad6f5d4bb634589ab95da6f2) 
- 루트 패키지에서 global 패키지로 이동하였습니다.
 
[feat(monitor) : MonitorController 추가](https://github.com/gombasan/endpoint-watchdog/commit/723e3679648f6b343c5433a0804781a29abf9967) 
- 모니터링을 시작하고 중지하는 서비스가 있는 controller 클래스를 추가하였습니다.
- view 페이지를 반환할것인지, 데이터만 반환할지 아직은 정하지 않았습니다.
- 가볍게 기능이 정상적으로 동작하는지 확인하기 위하여 간단하게 구현했습니다.
 
[feat(monitor) : MonitorService 추가](https://github.com/gombasan/endpoint-watchdog/commit/c2709690e957bef73d5daa17d65ab84dee2265f9) 
- startMonitoring, stopMonitoring 메서드를 추가하여 주기적으로 MonitorTask 를 실행하도록 구현하였습니다.
- MonitorTask 는 지정된 endPoint 에 대한 모니터링을 담당하며, 타이머를 사용하여 일정 간격으로 실행됩니다.
- stopMonitoring 메서드를 추가하여 모니터링을 중지하고 재시작을 위해 타이머를 초기화하는 기능을 구현하였습니다.
 
[feat(monitor): MonitorTask 클래스 추가](https://github.com/gombasan/endpoint-watchdog/commit/e76950ec610a299f4e020e3aad720c305cbc318b) 
- MonitorTask 클래스는 TimerTask 를 상속받아 구현된 클래스입니다.
- 해당 클래스는 Monitor 를 생성자로 주입 받아 모니터링을 수행하고, 실행 시간과 응답 상태 코드를 출력합니다.
- 각 MonitoringTask 는 독립적으로 실행되며, MonitorTask 의 run 메서드가 호출될 때마다 해당 모니터의 엔드포인트에 대한 요청을 보내고 결과를 출력합니다."
- 아직은 간단하게 기능 테스트를 위한 것으로, Get 으로 요청 시간과 HttpStatus 코드만 받도록 처리하였습니다.
- 추후에 다양한 옵션들을 사용 할 수 있도록 추가 할 예정입니다.
 
[feat(monitor): Monitor Entity 추가](https://github.com/gombasan/endpoint-watchdog/commit/0f992685584ba49412fcbf1f2335cfa3d502c36e) 
- 사용자가 모니터링을 하기 위한 속성들을 정의했습니다.
- interval 은 요청주기를 표현한 것이며, interval 이 h2 예약어이므로, heartbeat 로 변경하여 컬럼을 설정하였습니다.